### PR TITLE
no more rtsp, fallback for livestream

### DIFF
--- a/tagesschau_json_api.py
+++ b/tagesschau_json_api.py
@@ -67,12 +67,16 @@ class VideoContent(object):
 
         if quality == 'L':
             videourl = self._videourls.get("h264l")
+            if not videourl:
+                videourl = self._videourls.get("http_tab_high")
         if quality == 'M' or not videourl:    
             videourl = self._videourls.get("h264m")
+            if not videourl:
+                videourl = self._videourls.get("http_tab_normal")
         if quality == 'S' or not videourl:    
             videourl = self._videourls.get("h264s")
-        if not videourl:
-            videourl = self._videourls.get("rtsp_high")
+            if not videourl:
+                videourl = self._videourls.get("http_tab_normal")
         return videourl
 
     def image_url(self):


### PR DESCRIPTION
tagesschau has removed the RTSP streams that were previously used for live streams. 

I've switched to using one of the other video formats, which is working fine on raspbmc. 
However, my Frodo on Mac OSX seems to choke on both the "m3u8_A" and "http_tab" live streams. 

In any case, at least this commit fixes the concrete issue raised in https://github.com/joerns/xbmc-plugin.video.tagesschau/issues/5
