### PR TITLE
Re-enable subtitles

### DIFF
--- a/tagesschau.py
+++ b/tagesschau.py
@@ -140,7 +140,9 @@ if params.get(ACTION_PARAM) == 'play_video':
     if(subtitles_file != None):
         # the following only works in Gotham, see
         # http://forum.xbmc.org/showthread.php?tid=154805&page=7&highlight=subtitle
-        listitem.setProperty('upnp:subtitle:1', subtitles_file)             
+        listitem.setProperty('upnp:subtitle:1', subtitles_file)
+        listitem.setSubtitles((subtitles_file,))
+
     xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=(url != None), listitem=listitem)
 
 elif params.get(ACTION_PARAM) == 'list_feed':


### PR DESCRIPTION
Hi:

Until the last update of the version of Kodi in my media center (currently I have 15.2), subtitles were working fine, but for some days I couldn't see them.

So, debugging a litte bit, and after reading the URL already present in the source-code, I added this line to signal the server that this downloaded file should be used as subtitles.

Thank you for this plugin, it's helping me with learning German ;)